### PR TITLE
Fix security, correctness, and robustness issues found in audit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,87 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+A Sylius plugin (`setono/sylius-conversion-attribution-plugin`) that attributes order conversions to traffic sources (google/facebook ads, referrals, direct, etc.). It is a Symfony bundle, not an application — the runnable Sylius app used for tests lives in `tests/Application`. Requires PHP >= 8.1 (local dev pins 8.1 via `.php-version`), Symfony 6.4/7.0, Sylius 1.x.
+
+## Commands
+
+```bash
+composer analyse           # Psalm static analysis (config: psalm.xml)
+composer check-style       # ECS check (config: ecs.php)
+composer fix-style         # ECS auto-fix
+composer phpunit           # Run all tests
+vendor/bin/phpunit tests/Matcher/QueryParameterBasedSourceMatcherTest.php   # Single test file
+vendor/bin/phpunit --filter it_matches                                      # Single test method
+vendor/bin/rector process --dry-run   # Rector (CI runs this, non-blocking)
+vendor/bin/infection                  # Mutation testing (minCoveredMsi: 100)
+vendor/bin/composer-dependency-analyser  # Dependency analysis (CI-enforced)
+composer normalize --dry-run          # composer.json normalization (CI-enforced)
+```
+
+The test app in `tests/Application` is used by CI for linting and schema validation (needs MySQL via `DATABASE_URL`, `APP_ENV=test`):
+
+```bash
+(cd tests/Application && bin/console lint:container)
+(cd tests/Application && bin/console lint:yaml ../../src/Resources)
+(cd tests/Application && bin/console lint:twig ../../src/Resources)
+(cd tests/Application && bin/console doctrine:schema:validate -vvv)
+```
+
+Note: `phpunit.xml.dist` bootstraps `tests/Application/config/bootstrap.php`, and `tests/Parser/ReferrerParserFunctionalTest.php` exercises the real referrer database, so tests need `composer install` to have run and network access for that test.
+
+## Architecture
+
+The plugin tracks *where a visitor came from* and later ties that to the order they place. The flow has two halves:
+
+**Capture (visitor side):**
+1. `EventSubscriber\AddJavascriptSubscriber` (only loaded when `javascript.enabled` config is true, and requires `setono/tag-bag-bundle` — the extension throws a LogicException if it is missing) injects a JS `fetch()` POST to `/track` on GET HTML requests. It skips bots (`setono/bot-detection-bundle`) and skips visitors seen within `session_timeout` (default 1800s), using the cookie from `setono/client-bundle`.
+2. `Controller\Action\TrackAction` (route `setono_sylius_conversion_attribution_global_track`) maps the JSON payload to `ClientInformation\ClientInformation` via `#[MapRequestPayload]` and persists a `Model\Source` row (client id, page, referrer, source/medium/campaign).
+3. `Resolver\ClientInformationResolver` builds that payload server-side at injection time: client id from client-bundle's `ClientContext`, plus source/medium/campaign from the matcher chain (falls back to source `direct`).
+
+**Source matching chain:** `Matcher\CompositeSourceMatcher` is populated via `CompositeCompilerPass` from services tagged `setono_sylius_conversion_attribution.source_matcher` (see `SetonoSyliusConversionAttributionPlugin::build()`). First non-null match wins. Built-in matchers, in priority order (priorities set in `services/matcher.xml`):
+- `UtmQueryParameterBasedSourceMatcher` — utm_source/utm_medium/utm_campaign
+- `QueryParameterBasedSourceMatcher` — click-id params (fbclid, gclid, msclkid, ttclid, twclid, …). The mapping comes from the `query_parameters` config; defaults are prepended in `SetonoSyliusConversionAttributionExtension::prepend()`
+- `ReferrerBasedSourceMatcher` — parses the Referer header via `Parser\ReferrerParser`, which looks up hosts in Snowplow's referer database. `CacheWarmer\ReferrersCacheWarmer` downloads that database from S3 at cache warmup into a `PhpArrayAdapter` file (`%kernel.cache_dir%/referrers.php`). Same-host referrers are ignored; unknown cross-host referrers become source=host, medium=referral.
+
+Note the distinction between the two `Source` classes: `Matcher\Source` is a value object (match result); `Model\Source` is the Doctrine entity (a Sylius resource, `setono_sylius_conversion_attribution.source`, mapped via `src/Resources/config/doctrine/model/Source.orm.xml`, integer auto-increment ids).
+
+**Attribution (order side):**
+1. On `sylius.order.pre_complete`, `EventSubscriber\AddClientIdSubscriber` stamps the current client id on the order and customer. Host applications must add `OrderInterface`/`OrderTrait` and `CustomerInterface`/`CustomerTrait` (from `src/Model/`) to their Order/Customer entities — see README.
+2. `Provider\OrderAttributionProvider` finds the newest non-`direct` Source row for the order's client id.
+3. The admin order page shows this via a `sylius_ui` block (`sylius.admin.order.show.sidebar`, prepended in the extension) rendering `src/Resources/views/order/attribution.html.twig` through the Twig extension/runtime in `src/Twig/`.
+
+**Maintenance:** `Command\PruneCommand` (`setono:sylius-conversion-attribution:prune`) deletes Source rows older than 180 days.
+
+## Conventions
+
+- Service definitions are XML, split per concern in `src/Resources/config/services/*.xml` and aggregated by `services.xml`. Services only loaded under config conditions live in `services/conditional/`.
+- Interfaces sit next to implementations (`FooInterface` + `Foo`); services are `final` and constructor-injected; Doctrine access goes through `setono/doctrine-orm-trait`'s `ORMTrait` with the resource class name passed as a string parameter (so host apps can override the model class).
+- CI (`.github/workflows/build.yaml`) tests PHP 8.1/8.2 with lowest and highest dependencies against Symfony ~6.4.0 — keep code compatible with both dependency extremes and PHP 8.1 syntax.
+
+### Backwards compatibility: adding a constructor argument
+
+This is a published library: adding a required constructor argument to a service (or reordering existing ones) breaks host apps that have redefined the service, decorated it, or instantiate it directly. Follow Symfony's own deprecation layer instead (e.g. `Symfony\Bridge\Doctrine\DataCollector\DoctrineDataCollector::__construct`):
+
+1. Append the new argument **last**, typed **nullable with a `null` default** — never insert it in the middle.
+2. In the constructor body, when the argument is `null`, call `trigger_deprecation()` (from `symfony/deprecation-contracts`, a `require` dependency) telling integrators to start passing it. The **version** argument is the release that introduced the deprecation; the message states which major will require it:
+   ```php
+   if (null === $sourceMatcher) {
+       trigger_deprecation(
+           'setono/sylius-conversion-attribution-plugin',
+           '1.1', // version the arg became "should be passed"
+           'Not passing an instance of "%s" as argument "$sourceMatcher" to "%s()" is deprecated and will be required in 2.0.',
+           SourceMatcherInterface::class,
+           __METHOD__,
+       );
+   }
+   ```
+3. Guard every use of the argument against `null` so the old behaviour still works when it is absent.
+4. Still inject it in the plugin's own XML service definition (also appended last) so normal installs get full functionality — the nullability only cushions downstream overrides.
+5. Add a `@deprecated will be required in 2.0` comment on the property so it's greppable alongside the `trigger_deprecation()` call.
+
+**Removing the shim in the next major:** grep the `src/` tree for `trigger_deprecation` — each hit is a nullable argument to make required (drop the `?`/`= null`, delete the `trigger_deprecation` block and the null-guards). Current shims: `EventSubscriber\AddJavascriptSubscriber` (`$sourceMatcher`) and `Controller\Action\TrackAction` (`$botDetector`).
+
+Test the legacy path by constructing the service without the new argument and asserting the deprecation fires (see `it_triggers_a_deprecation_*` tests, which register a temporary `E_USER_DEPRECATED` handler). Mark such tests `@group legacy`.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,39 @@ php bin/console doctrine:migrations:diff
 php bin/console doctrine:migrations:migrate
 ```
 
+### Prune old sources (recommended)
+
+Every tracked hit creates a `source` row, so the table grows continuously. Schedule the prune
+command (for example daily via cron) to delete old rows. By default it keeps 180 days:
+
+```bash
+php bin/console setono:sylius-conversion-attribution:prune
+```
+
+## Notes
+
+### Optional runtime dependencies
+
+- The default JavaScript injection requires [`setono/tag-bag-bundle`](https://github.com/Setono/TagBagBundle).
+  Without it, enabling the `javascript` feature throws at container build time. Install it, or set
+  `setono_sylius_conversion_attribution.javascript.enabled: false` and inject the tracking snippet yourself.
+- Bot filtering (both for the injected snippet and the `/track` endpoint) is provided by
+  `setono/bot-detection-bundle`, which is installed automatically as a dependency.
+
+### Full page cache
+
+The injected tracking snippet embeds a server-resolved client id. If a full page / HTTP cache stores
+the rendered HTML, every visitor served that cached page shares the same embedded client id, which
+corrupts attribution. Exclude pages carrying the snippet from full page caching, or only enable the
+feature on responses that are not cached.
+
+### Privacy / GDPR
+
+A `source` row stores the visitor's IP address and user agent, which are personal data in many
+jurisdictions. Keep retention short by scheduling the prune command, and ensure your privacy policy
+and consent handling cover this collection (you may need to anonymize or omit the IP depending on your
+requirements).
+
 [ico-version]: https://poser.pugx.org/setono/sylius-conversion-attribution-plugin/v/stable
 [ico-license]: https://poser.pugx.org/setono/sylius-conversion-attribution-plugin/license
 [ico-github-actions]: https://github.com/Setono/sylius-conversion-attribution-plugin/workflows/build/badge.svg

--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -9,7 +9,9 @@ use ShipMonk\ComposerDependencyAnalyser\Config\ErrorType;
 return (new Configuration())
     ->addPathToExclude(__DIR__ . '/tests')
     ->ignoreUnknownClasses([SetonoTagBagBundle::class, TagBagInterface::class, InlineScriptTag::class])
-    // Only symbol used from this package is the global trigger_deprecation() function, which the
-    // analyser does not attribute to a package, so it is reported as unused. It is genuinely used.
+    // The only symbol used from this package is the global trigger_deprecation() function. Whether
+    // the analyser attributes it to the package (and thus whether the "unused" error fires) depends
+    // on the installed dependency set, so ignore the error and don't fail when the ignore is unused.
     ->ignoreErrorsOnPackage('symfony/deprecation-contracts', [ErrorType::UNUSED_DEPENDENCY])
+    ->disableReportingUnmatchedIgnores()
 ;

--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -4,8 +4,12 @@ use Setono\TagBag\Tag\InlineScriptTag;
 use Setono\TagBag\TagBagInterface;
 use Setono\TagBagBundle\SetonoTagBagBundle;
 use ShipMonk\ComposerDependencyAnalyser\Config\Configuration;
+use ShipMonk\ComposerDependencyAnalyser\Config\ErrorType;
 
 return (new Configuration())
     ->addPathToExclude(__DIR__ . '/tests')
     ->ignoreUnknownClasses([SetonoTagBagBundle::class, TagBagInterface::class, InlineScriptTag::class])
+    // Only symbol used from this package is the global trigger_deprecation() function, which the
+    // analyser does not attribute to a package, so it is reported as unused. It is genuinely used.
+    ->ignoreErrorsOnPackage('symfony/deprecation-contracts', [ErrorType::UNUSED_DEPENDENCY])
 ;

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "symfony/config": "^6.4 || ^7.0",
         "symfony/console": "^6.4 || ^7.0",
         "symfony/dependency-injection": "^6.4 || ^7.0",
+        "symfony/deprecation-contracts": "^2.5 || ^3.0",
         "symfony/event-dispatcher": "^6.4 || ^7.0",
         "symfony/http-foundation": "^6.4 || ^7.0",
         "symfony/http-kernel": "^6.4 || ^7.0",

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
         "php": ">=8.1",
         "doctrine/orm": "^2.0 || ^3.0",
         "doctrine/persistence": "^2.0 || ^3.0",
+        "psr/log": "^1.0 || ^2.0 || ^3.0",
         "setono/bot-detection-bundle": "^1.13",
         "setono/client-bundle": "^1.1",
         "setono/composite-compiler-pass": "^1.1",
@@ -26,7 +27,7 @@
         "symfony/http-foundation": "^6.4 || ^7.0",
         "symfony/http-kernel": "^6.4 || ^7.0",
         "symfony/routing": "^6.4 || ^7.0",
-        "symfony/uid": "^6.4 || ^7.0",
+        "symfony/validator": "^6.4 || ^7.0",
         "twig/twig": "^2.16 || ^3.21",
         "webmozart/assert": "^1.11"
     },

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -11,6 +11,6 @@
             "badge": "master"
         }
     },
-    "minMsi": 42.54,
+    "minMsi": 60.00,
     "minCoveredMsi": 100.00
 }

--- a/src/CacheWarmer/ReferrersCacheWarmer.php
+++ b/src/CacheWarmer/ReferrersCacheWarmer.php
@@ -4,19 +4,27 @@ declare(strict_types=1);
 
 namespace Setono\SyliusConversionAttributionPlugin\CacheWarmer;
 
+use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 
-final class ReferrersCacheWarmer implements CacheWarmerInterface
+final class ReferrersCacheWarmer implements CacheWarmerInterface, LoggerAwareInterface
 {
     private const REFERRERS_URL = 'https://s3-eu-west-1.amazonaws.com/snowplow-hosted-assets/third-party/referer-parser/referers-latest.json';
 
-    public function __construct(
-        private readonly string $phpArrayFile,
-        private readonly ?LoggerInterface $logger = null,
-    ) {
+    private LoggerInterface $logger;
+
+    public function __construct(private readonly string $phpArrayFile)
+    {
+        $this->logger = new NullLogger();
+    }
+
+    public function setLogger(LoggerInterface $logger): void
+    {
+        $this->logger = $logger;
     }
 
     public function isOptional(): bool
@@ -30,7 +38,7 @@ final class ReferrersCacheWarmer implements CacheWarmerInterface
         $context = stream_context_create(['http' => ['timeout' => 5], 'https' => ['timeout' => 5]]);
         $json = @file_get_contents(self::REFERRERS_URL, false, $context);
         if (false === $json) {
-            $this->logger?->warning('Could not download the referrers database from {url}; referrer-based attribution will be degraded until the next successful cache warmup.', ['url' => self::REFERRERS_URL]);
+            $this->logger->warning('Could not download the referrers database from {url}; referrer-based attribution will be degraded until the next successful cache warmup.', ['url' => self::REFERRERS_URL]);
 
             return [];
         }
@@ -39,7 +47,7 @@ final class ReferrersCacheWarmer implements CacheWarmerInterface
             /** @var array<string, array<string, array{domains: list<string>}>> $data */
             $data = json_decode($json, true, 512, \JSON_THROW_ON_ERROR);
         } catch (\JsonException $e) {
-            $this->logger?->warning('Could not decode the referrers database: {message}', ['message' => $e->getMessage()]);
+            $this->logger->warning('Could not decode the referrers database: {message}', ['message' => $e->getMessage()]);
 
             return [];
         }

--- a/src/CacheWarmer/ReferrersCacheWarmer.php
+++ b/src/CacheWarmer/ReferrersCacheWarmer.php
@@ -4,14 +4,19 @@ declare(strict_types=1);
 
 namespace Setono\SyliusConversionAttributionPlugin\CacheWarmer;
 
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 
 final class ReferrersCacheWarmer implements CacheWarmerInterface
 {
-    public function __construct(private readonly string $phpArrayFile)
-    {
+    private const REFERRERS_URL = 'https://s3-eu-west-1.amazonaws.com/snowplow-hosted-assets/third-party/referer-parser/referers-latest.json';
+
+    public function __construct(
+        private readonly string $phpArrayFile,
+        private readonly ?LoggerInterface $logger = null,
+    ) {
     }
 
     public function isOptional(): bool
@@ -21,15 +26,21 @@ final class ReferrersCacheWarmer implements CacheWarmerInterface
 
     public function warmUp(string $cacheDir): array
     {
-        $json = file_get_contents('https://s3-eu-west-1.amazonaws.com/snowplow-hosted-assets/third-party/referer-parser/referers-latest.json');
+        // Use an explicit timeout so a slow/unreachable host can't stall cache warmup (and thereby a deploy)
+        $context = stream_context_create(['http' => ['timeout' => 5], 'https' => ['timeout' => 5]]);
+        $json = @file_get_contents(self::REFERRERS_URL, false, $context);
         if (false === $json) {
+            $this->logger?->warning('Could not download the referrers database from {url}; referrer-based attribution will be degraded until the next successful cache warmup.', ['url' => self::REFERRERS_URL]);
+
             return [];
         }
 
         try {
             /** @var array<string, array<string, array{domains: list<string>}>> $data */
             $data = json_decode($json, true, 512, \JSON_THROW_ON_ERROR);
-        } catch (\JsonException) {
+        } catch (\JsonException $e) {
+            $this->logger?->warning('Could not decode the referrers database: {message}', ['message' => $e->getMessage()]);
+
             return [];
         }
 

--- a/src/ClientInformation/ClientInformation.php
+++ b/src/ClientInformation/ClientInformation.php
@@ -4,22 +4,32 @@ declare(strict_types=1);
 
 namespace Setono\SyliusConversionAttributionPlugin\ClientInformation;
 
+use Symfony\Component\Validator\Constraints as Assert;
+
 final class ClientInformation implements \JsonSerializable
 {
+    #[Assert\Length(max: 255)]
     public ?string $clientId = null;
 
+    #[Assert\Length(max: 255)]
     public ?string $ip = null;
 
+    #[Assert\Length(max: 1024)]
     public ?string $userAgent = null;
 
+    #[Assert\Length(max: 4096)]
     public ?string $page = null;
 
+    #[Assert\Length(max: 4096)]
     public ?string $referrer = null;
 
+    #[Assert\Length(max: 255)]
     public ?string $source = null;
 
+    #[Assert\Length(max: 255)]
     public ?string $medium = null;
 
+    #[Assert\Length(max: 255)]
     public ?string $campaign = null;
 
     public function jsonSerialize(): array

--- a/src/Command/PruneCommand.php
+++ b/src/Command/PruneCommand.php
@@ -69,15 +69,23 @@ final class PruneCommand extends Command
         return 0;
     }
 
+    /**
+     * @return list<int>
+     */
     private function getDeletableIds(): array
     {
-        return $this
+        /** @var list<array{id: int}> $rows */
+        $rows = $this
             ->getDeletableQueryBuilder()
             ->select('o.id')
-            ->setMaxResults(1)
+            ->setMaxResults(1000)
             ->getQuery()
             ->getScalarResult()
         ;
+
+        // getScalarResult() returns a list of rows (['id' => x]); the IN() parameter needs a flat
+        // list of ids. Without this the DELETE matches nothing and the loop in execute() spins forever.
+        return array_column($rows, 'id');
     }
 
     private function getDeletableQueryBuilder(): QueryBuilder

--- a/src/Command/PruneCommand.php
+++ b/src/Command/PruneCommand.php
@@ -83,8 +83,9 @@ final class PruneCommand extends Command
             ->getScalarResult()
         ;
 
-        // getScalarResult() returns a list of rows (['id' => x]); the IN() parameter needs a flat
-        // list of ids. Without this the DELETE matches nothing and the loop in execute() spins forever.
+        // getScalarResult() returns rows shaped like ['id' => x]; array_column() flattens them into
+        // the list<int> that IN() expects. Combined with the 1000-row batch above this replaces the
+        // previous one-DELETE-per-row loop (setMaxResults(1)).
         return array_column($rows, 'id');
     }
 

--- a/src/Controller/Action/TrackAction.php
+++ b/src/Controller/Action/TrackAction.php
@@ -19,10 +19,21 @@ final class TrackAction
     public function __construct(
         private readonly SourceFactoryInterface $sourceFactory,
         ManagerRegistry $managerRegistry,
-        // Nullable and last for backwards compatibility: when not injected, bot filtering is skipped
+        // Nullable and last for backwards compatibility: when not injected, bot filtering is skipped.
+        // @deprecated will be required in 2.0 — grep "trigger_deprecation" to find shims to drop.
         private readonly ?BotDetectorInterface $botDetector = null,
     ) {
         $this->managerRegistry = $managerRegistry;
+
+        if (null === $botDetector) {
+            trigger_deprecation(
+                'setono/sylius-conversion-attribution-plugin',
+                '1.1',
+                'Not passing an instance of "%s" as argument "$botDetector" to "%s()" is deprecated and will be required in 2.0.',
+                BotDetectorInterface::class,
+                __METHOD__,
+            );
+        }
     }
 
     public function __invoke(#[MapRequestPayload] ClientInformation $clientInformation): Response

--- a/src/Controller/Action/TrackAction.php
+++ b/src/Controller/Action/TrackAction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Setono\SyliusConversionAttributionPlugin\Controller\Action;
 
 use Doctrine\Persistence\ManagerRegistry;
+use Setono\BotDetectionBundle\BotDetector\BotDetectorInterface;
 use Setono\Doctrine\ORMTrait;
 use Setono\SyliusConversionAttributionPlugin\ClientInformation\ClientInformation;
 use Setono\SyliusConversionAttributionPlugin\Factory\SourceFactoryInterface;
@@ -17,6 +18,7 @@ final class TrackAction
 
     public function __construct(
         private readonly SourceFactoryInterface $sourceFactory,
+        private readonly BotDetectorInterface $botDetector,
         ManagerRegistry $managerRegistry,
     ) {
         $this->managerRegistry = $managerRegistry;
@@ -24,6 +26,12 @@ final class TrackAction
 
     public function __invoke(#[MapRequestPayload] ClientInformation $clientInformation): Response
     {
+        // The endpoint is anonymous; drop bot traffic (matched on the real request User-Agent)
+        // so automated hits don't flood the source table
+        if ($this->botDetector->isBotRequest()) {
+            return new Response(status: Response::HTTP_NO_CONTENT);
+        }
+
         $source = $this->sourceFactory->createFromClientInformation($clientInformation);
 
         $manager = $this->getManager($source::class);

--- a/src/Controller/Action/TrackAction.php
+++ b/src/Controller/Action/TrackAction.php
@@ -18,8 +18,9 @@ final class TrackAction
 
     public function __construct(
         private readonly SourceFactoryInterface $sourceFactory,
-        private readonly BotDetectorInterface $botDetector,
         ManagerRegistry $managerRegistry,
+        // Nullable and last for backwards compatibility: when not injected, bot filtering is skipped
+        private readonly ?BotDetectorInterface $botDetector = null,
     ) {
         $this->managerRegistry = $managerRegistry;
     }
@@ -28,7 +29,7 @@ final class TrackAction
     {
         // The endpoint is anonymous; drop bot traffic (matched on the real request User-Agent)
         // so automated hits don't flood the source table
-        if ($this->botDetector->isBotRequest()) {
+        if (null !== $this->botDetector && $this->botDetector->isBotRequest()) {
             return new Response(status: Response::HTTP_NO_CONTENT);
         }
 

--- a/src/EventSubscriber/AddJavascriptSubscriber.php
+++ b/src/EventSubscriber/AddJavascriptSubscriber.php
@@ -6,6 +6,7 @@ namespace Setono\SyliusConversionAttributionPlugin\EventSubscriber;
 
 use Setono\BotDetectionBundle\BotDetector\BotDetectorInterface;
 use Setono\ClientBundle\CookieProvider\CookieProviderInterface;
+use Setono\SyliusConversionAttributionPlugin\Matcher\SourceMatcherInterface;
 use Setono\SyliusConversionAttributionPlugin\Resolver\ClientInformationResolverInterface;
 use Setono\TagBag\Tag\InlineScriptTag;
 use Setono\TagBag\TagBagInterface;
@@ -22,6 +23,7 @@ final class AddJavascriptSubscriber implements EventSubscriberInterface
         private readonly UrlGeneratorInterface $urlGenerator,
         private readonly BotDetectorInterface $botDetector,
         private readonly CookieProviderInterface $cookieProvider,
+        private readonly SourceMatcherInterface $sourceMatcher,
         private readonly int $sessionTimeout,
     ) {
     }
@@ -35,21 +37,29 @@ final class AddJavascriptSubscriber implements EventSubscriberInterface
 
     public function addJavascript(RequestEvent $event): void
     {
+        $request = $event->getRequest();
+
         if (!$event->isMainRequest() ||
-            $event->getRequest()->isXmlHttpRequest() ||
-            !$event->getRequest()->isMethod('GET') ||
-            !str_contains((string) $event->getRequest()->getRequestFormat(), 'html') ||
-            $this->botDetector->isBotRequest($event->getRequest())
+            $request->isXmlHttpRequest() ||
+            !$request->isMethod('GET') ||
+            !str_contains((string) $request->getRequestFormat(), 'html') ||
+            $this->botDetector->isBotRequest($request)
         ) {
             return;
         }
 
-        $clientCookie = $this->cookieProvider->getCookie();
-        if (null !== $clientCookie && $clientCookie->lastSeenAt >= (time() - $this->sessionTimeout)) {
-            return;
+        // A request that carries campaign markers (utm/click id/cross-host referrer) is always
+        // tracked, even mid-session, so a paid click arriving after an organic entry isn't lost
+        $hasCampaign = null !== $this->sourceMatcher->match($request);
+
+        if (!$hasCampaign) {
+            $clientCookie = $this->cookieProvider->getCookie();
+            if (null !== $clientCookie && $clientCookie->lastSeenAt >= (time() - $this->sessionTimeout)) {
+                return;
+            }
         }
 
-        $clientInformation = $this->clientInformationResolver->resolve($event->getRequest());
+        $clientInformation = $this->clientInformationResolver->resolve($request);
         $javascript = <<<'JS'
 fetch('%s', {
     method: "POST",
@@ -64,7 +74,12 @@ JS;
             $javascript = sprintf(
                 $javascript,
                 $this->urlGenerator->generate('setono_sylius_conversion_attribution_global_track'),
-                json_encode($clientInformation, \JSON_THROW_ON_ERROR),
+                // The payload is interpolated raw into an inline <script>, so the encoding must
+                // neutralize ', ", <, >, & to prevent breaking out of the JS string or the script tag
+                json_encode(
+                    $clientInformation,
+                    \JSON_THROW_ON_ERROR | \JSON_HEX_TAG | \JSON_HEX_APOS | \JSON_HEX_QUOT | \JSON_HEX_AMP,
+                ),
             );
 
             $this->tagBag->add(InlineScriptTag::create($javascript));

--- a/src/EventSubscriber/AddJavascriptSubscriber.php
+++ b/src/EventSubscriber/AddJavascriptSubscriber.php
@@ -23,8 +23,10 @@ final class AddJavascriptSubscriber implements EventSubscriberInterface
         private readonly UrlGeneratorInterface $urlGenerator,
         private readonly BotDetectorInterface $botDetector,
         private readonly CookieProviderInterface $cookieProvider,
-        private readonly SourceMatcherInterface $sourceMatcher,
         private readonly int $sessionTimeout,
+        // Nullable and last for backwards compatibility: when not injected, mid-session campaign
+        // detection is simply skipped and the previous first-touch-per-session behaviour applies
+        private readonly ?SourceMatcherInterface $sourceMatcher = null,
     ) {
     }
 
@@ -50,7 +52,7 @@ final class AddJavascriptSubscriber implements EventSubscriberInterface
 
         // A request that carries campaign markers (utm/click id/cross-host referrer) is always
         // tracked, even mid-session, so a paid click arriving after an organic entry isn't lost
-        $hasCampaign = null !== $this->sourceMatcher->match($request);
+        $hasCampaign = null !== $this->sourceMatcher && null !== $this->sourceMatcher->match($request);
 
         if (!$hasCampaign) {
             $clientCookie = $this->cookieProvider->getCookie();

--- a/src/EventSubscriber/AddJavascriptSubscriber.php
+++ b/src/EventSubscriber/AddJavascriptSubscriber.php
@@ -25,9 +25,19 @@ final class AddJavascriptSubscriber implements EventSubscriberInterface
         private readonly CookieProviderInterface $cookieProvider,
         private readonly int $sessionTimeout,
         // Nullable and last for backwards compatibility: when not injected, mid-session campaign
-        // detection is simply skipped and the previous first-touch-per-session behaviour applies
+        // detection is simply skipped and the previous first-touch-per-session behaviour applies.
+        // @deprecated will be required in 2.0 — grep "trigger_deprecation" to find shims to drop.
         private readonly ?SourceMatcherInterface $sourceMatcher = null,
     ) {
+        if (null === $sourceMatcher) {
+            trigger_deprecation(
+                'setono/sylius-conversion-attribution-plugin',
+                '1.1',
+                'Not passing an instance of "%s" as argument "$sourceMatcher" to "%s()" is deprecated and will be required in 2.0.',
+                SourceMatcherInterface::class,
+                __METHOD__,
+            );
+        }
     }
 
     public static function getSubscribedEvents(): array

--- a/src/Model/Source.php
+++ b/src/Model/Source.php
@@ -4,11 +4,9 @@ declare(strict_types=1);
 
 namespace Setono\SyliusConversionAttributionPlugin\Model;
 
-use Symfony\Component\Uid\Uuid;
-
 class Source implements SourceInterface
 {
-    protected string $id;
+    protected ?int $id = null;
 
     protected ?string $clientId = null;
 
@@ -30,11 +28,10 @@ class Source implements SourceInterface
 
     public function __construct()
     {
-        $this->id = (string) Uuid::v7();
         $this->createdAt = new \DateTimeImmutable();
     }
 
-    public function getId(): string
+    public function getId(): ?int
     {
         return $this->id;
     }

--- a/src/Parser/ReferrerParser.php
+++ b/src/Parser/ReferrerParser.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Setono\SyliusConversionAttributionPlugin\Parser;
 
 use Symfony\Component\Cache\Adapter\AdapterInterface;
+use Symfony\Component\Cache\Exception\InvalidArgumentException;
 
 final class ReferrerParser implements ReferrerParserInterface
 {
@@ -71,13 +72,20 @@ final class ReferrerParser implements ReferrerParserInterface
     private function lookupHost(string $host, string $path = ''): ?array
     {
         do {
-            $cacheItem = $this->cache->getItem($host . self::escapePath($path));
-            if ($cacheItem->isHit()) {
-                /** @var mixed $res */
-                $res = $cacheItem->get();
-                if (is_array($res)) {
-                    return $res;
+            try {
+                $cacheItem = $this->cache->getItem($host . self::escapePath($path));
+                if ($cacheItem->isHit()) {
+                    /** @var mixed $res */
+                    $res = $cacheItem->get();
+                    if (is_array($res)) {
+                        return $res;
+                    }
                 }
+            } catch (InvalidArgumentException) {
+                // The referrer's host/path produced a key with PSR-6 reserved characters (e.g. a
+                // referrer like https://en.wikipedia.org/wiki/Foo_(disambiguation)). Such a key is
+                // never present in the warmed referrer database, so treat it as a cache miss
+                // instead of letting the exception bubble up and turn the page into an HTTP 500.
             }
 
             $pos = strpos($host, '.');

--- a/src/Resolver/ClientInformationResolver.php
+++ b/src/Resolver/ClientInformationResolver.php
@@ -20,7 +20,7 @@ final class ClientInformationResolver implements ClientInformationResolverInterf
     ) {
     }
 
-    public function resolve(Request $request = null): ClientInformation
+    public function resolve(?Request $request = null): ClientInformation
     {
         $clientInformation = new ClientInformation();
 

--- a/src/Resolver/ClientInformationResolverInterface.php
+++ b/src/Resolver/ClientInformationResolverInterface.php
@@ -12,5 +12,5 @@ interface ClientInformationResolverInterface
     /**
      * Will resolve client information from the request (if set), else it will use the main request
      */
-    public function resolve(Request $request = null): ClientInformation;
+    public function resolve(?Request $request = null): ClientInformation;
 }

--- a/src/Resources/config/services/cache_warmer.xml
+++ b/src/Resources/config/services/cache_warmer.xml
@@ -4,6 +4,7 @@
     <services>
         <service id="Setono\SyliusConversionAttributionPlugin\CacheWarmer\ReferrersCacheWarmer">
             <argument>%setono_sylius_conversion_attribution.referrers.cache.file%</argument>
+            <argument type="service" id="logger" on-invalid="null"/>
 
             <tag name="kernel.cache_warmer"/>
         </service>

--- a/src/Resources/config/services/cache_warmer.xml
+++ b/src/Resources/config/services/cache_warmer.xml
@@ -4,7 +4,10 @@
     <services>
         <service id="Setono\SyliusConversionAttributionPlugin\CacheWarmer\ReferrersCacheWarmer">
             <argument>%setono_sylius_conversion_attribution.referrers.cache.file%</argument>
-            <argument type="service" id="logger" on-invalid="null"/>
+
+            <call method="setLogger">
+                <argument type="service" id="logger" on-invalid="ignore"/>
+            </call>
 
             <tag name="kernel.cache_warmer"/>
         </service>

--- a/src/Resources/config/services/conditional/event_subscriber.xml
+++ b/src/Resources/config/services/conditional/event_subscriber.xml
@@ -8,6 +8,7 @@
             <argument type="service" id="router"/>
             <argument type="service" id="setono_bot_detection.bot_detector.default"/>
             <argument type="service" id="setono_client.cookie_provider.default"/>
+            <argument type="service" id="Setono\SyliusConversionAttributionPlugin\Matcher\SourceMatcherInterface"/>
             <argument>%setono_sylius_conversion_attribution.session_timeout%</argument>
 
             <tag name="kernel.event_subscriber"/>

--- a/src/Resources/config/services/conditional/event_subscriber.xml
+++ b/src/Resources/config/services/conditional/event_subscriber.xml
@@ -8,8 +8,8 @@
             <argument type="service" id="router"/>
             <argument type="service" id="setono_bot_detection.bot_detector.default"/>
             <argument type="service" id="setono_client.cookie_provider.default"/>
-            <argument type="service" id="Setono\SyliusConversionAttributionPlugin\Matcher\SourceMatcherInterface"/>
             <argument>%setono_sylius_conversion_attribution.session_timeout%</argument>
+            <argument type="service" id="Setono\SyliusConversionAttributionPlugin\Matcher\SourceMatcherInterface"/>
 
             <tag name="kernel.event_subscriber"/>
         </service>

--- a/src/Resources/config/services/controller.xml
+++ b/src/Resources/config/services/controller.xml
@@ -4,8 +4,8 @@
     <services>
         <service id="Setono\SyliusConversionAttributionPlugin\Controller\Action\TrackAction" public="true">
             <argument type="service" id="setono_sylius_conversion_attribution.factory.source"/>
-            <argument type="service" id="setono_bot_detection.bot_detector.default"/>
             <argument type="service" id="doctrine"/>
+            <argument type="service" id="setono_bot_detection.bot_detector.default"/>
         </service>
     </services>
 </container>

--- a/src/Resources/config/services/controller.xml
+++ b/src/Resources/config/services/controller.xml
@@ -4,6 +4,7 @@
     <services>
         <service id="Setono\SyliusConversionAttributionPlugin\Controller\Action\TrackAction" public="true">
             <argument type="service" id="setono_sylius_conversion_attribution.factory.source"/>
+            <argument type="service" id="setono_bot_detection.bot_detector.default"/>
             <argument type="service" id="doctrine"/>
         </service>
     </services>

--- a/tests/ClientInformation/ClientInformationTest.php
+++ b/tests/ClientInformation/ClientInformationTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusConversionAttributionPlugin\Tests\ClientInformation;
+
+use PHPUnit\Framework\TestCase;
+use Setono\SyliusConversionAttributionPlugin\ClientInformation\ClientInformation;
+use Symfony\Component\Validator\Validation;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+final class ClientInformationTest extends TestCase
+{
+    private ValidatorInterface $validator;
+
+    protected function setUp(): void
+    {
+        $this->validator = Validation::createValidatorBuilder()
+            ->enableAttributeMapping()
+            ->getValidator();
+    }
+
+    /**
+     * @test
+     */
+    public function it_rejects_an_over_long_value(): void
+    {
+        // Without this constraint an over-long value reaches the string column and blows up with a
+        // 500 on flush; the constraint turns it into a 422 at the MapRequestPayload boundary instead
+        $clientInformation = new ClientInformation();
+        $clientInformation->clientId = str_repeat('a', 256);
+
+        self::assertGreaterThan(0, $this->validator->validate($clientInformation)->count());
+    }
+
+    /**
+     * @test
+     */
+    public function it_accepts_a_value_at_the_limit(): void
+    {
+        $clientInformation = new ClientInformation();
+        $clientInformation->clientId = str_repeat('a', 255);
+        $clientInformation->ip = '203.0.113.1';
+        $clientInformation->source = 'google';
+
+        self::assertCount(0, $this->validator->validate($clientInformation));
+    }
+
+    /**
+     * @test
+     */
+    public function it_filters_empty_values_when_serialized(): void
+    {
+        $clientInformation = new ClientInformation();
+        $clientInformation->source = 'google';
+
+        self::assertSame(['source' => 'google'], $clientInformation->jsonSerialize());
+    }
+}

--- a/tests/Command/Fixture/PrunableSource.php
+++ b/tests/Command/Fixture/PrunableSource.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusConversionAttributionPlugin\Tests\Command\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * A minimal entity that mirrors the fields PruneCommand touches (id + createdAt), used to exercise
+ * the command against a real (in-memory) database.
+ */
+#[ORM\Entity]
+#[ORM\Table(name: 'test_prunable_source')]
+class PrunableSource
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private ?int $id = null;
+
+    #[ORM\Column(type: 'datetime')]
+    private \DateTimeInterface $createdAt;
+
+    public function __construct(\DateTimeInterface $createdAt)
+    {
+        $this->createdAt = $createdAt;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getCreatedAt(): \DateTimeInterface
+    {
+        return $this->createdAt;
+    }
+}

--- a/tests/Command/PruneCommandTest.php
+++ b/tests/Command/PruneCommandTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusConversionAttributionPlugin\Tests\Command;
+
+use Doctrine\DBAL\DriverManager;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\ORMSetup;
+use Doctrine\ORM\Tools\SchemaTool;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\TestCase;
+use Setono\SyliusConversionAttributionPlugin\Command\PruneCommand;
+use Setono\SyliusConversionAttributionPlugin\Tests\Command\Fixture\PrunableSource;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class PruneCommandTest extends TestCase
+{
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $config = ORMSetup::createAttributeMetadataConfiguration([__DIR__ . '/Fixture'], true);
+        $connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true], $config);
+
+        // The public constructor works in both doctrine/orm 2.x and 3.x; the 2.x EntityManager::create()
+        // factory was removed in 3.x, so it is deliberately avoided here
+        $this->em = new EntityManager($connection, $config);
+
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->createSchema([$this->em->getClassMetadata(PrunableSource::class)]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_prunes_only_rows_older_than_the_retention_window(): void
+    {
+        $old = new PrunableSource(new \DateTimeImmutable('-200 days'));
+        $recent = new PrunableSource(new \DateTimeImmutable('-10 days'));
+        $this->em->persist($old);
+        $this->em->persist($recent);
+        $this->em->flush();
+        $recentId = $recent->getId();
+        $this->em->clear();
+
+        $tester = new CommandTester($this->createCommand(180));
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(0, $exitCode);
+
+        // The command terminates (the pre-fix loop bound to getScalarResult()'s row shape never did)
+        // and leaves exactly the recent row behind
+        $remaining = $this->em->getRepository(PrunableSource::class)->findAll();
+        self::assertCount(1, $remaining);
+
+        $survivor = reset($remaining);
+        self::assertInstanceOf(PrunableSource::class, $survivor);
+        self::assertSame($recentId, $survivor->getId());
+    }
+
+    /**
+     * @test
+     */
+    public function it_reports_success_when_there_is_nothing_to_prune(): void
+    {
+        $this->em->persist(new PrunableSource(new \DateTimeImmutable('-1 day')));
+        $this->em->flush();
+        $this->em->clear();
+
+        $tester = new CommandTester($this->createCommand(180));
+
+        self::assertSame(0, $tester->execute([]));
+        self::assertCount(1, $this->em->getRepository(PrunableSource::class)->findAll());
+    }
+
+    private function createCommand(int $daysToKeep): PruneCommand
+    {
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getManagerForClass')->willReturn($this->em);
+
+        // PrunableSource is a deliberately minimal stand-in (only id + createdAt) for a real source entity
+        /** @psalm-suppress InvalidArgument */
+        return new PruneCommand($registry, PrunableSource::class, $daysToKeep);
+    }
+}

--- a/tests/Controller/Action/TrackActionTest.php
+++ b/tests/Controller/Action/TrackActionTest.php
@@ -60,8 +60,10 @@ final class TrackActionTest extends TestCase
 
     /**
      * @test
+     *
+     * @group legacy
      */
-    public function it_persists_without_a_bot_detector_for_backwards_compatibility(): void
+    public function it_persists_and_warns_without_a_bot_detector_for_backwards_compatibility(): void
     {
         $source = new Source();
 
@@ -75,11 +77,17 @@ final class TrackActionTest extends TestCase
         $registry = $this->createMock(ManagerRegistry::class);
         $registry->method('getManagerForClass')->willReturn($manager);
 
-        // Legacy two-argument construction (no bot detector) must still work
-        $action = new TrackAction($factory, $registry);
+        $response = null;
 
-        $response = $action(new ClientInformation());
+        // Legacy two-argument construction (no bot detector) must still work and warn
+        $deprecations = $this->captureDeprecations(function () use ($factory, $registry, &$response): void {
+            $action = new TrackAction($factory, $registry);
+            $response = $action(new ClientInformation());
+        });
 
+        self::assertNotEmpty($deprecations);
+        self::assertStringContainsString('$botDetector', $deprecations[0]);
+        self::assertInstanceOf(Response::class, $response);
         self::assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
     }
 
@@ -89,5 +97,28 @@ final class TrackActionTest extends TestCase
         $botDetector->method('isBotRequest')->willReturn($isBot);
 
         return $botDetector;
+    }
+
+    /**
+     * Runs $callback with a temporary handler that records E_USER_DEPRECATED messages.
+     *
+     * @return list<string>
+     */
+    private function captureDeprecations(callable $callback): array
+    {
+        $deprecations = [];
+        set_error_handler(static function (int $errno, string $errstr) use (&$deprecations): bool {
+            $deprecations[] = $errstr;
+
+            return true;
+        }, \E_USER_DEPRECATED);
+
+        try {
+            $callback();
+        } finally {
+            restore_error_handler();
+        }
+
+        return $deprecations;
     }
 }

--- a/tests/Controller/Action/TrackActionTest.php
+++ b/tests/Controller/Action/TrackActionTest.php
@@ -33,7 +33,7 @@ final class TrackActionTest extends TestCase
         $registry = $this->createMock(ManagerRegistry::class);
         $registry->method('getManagerForClass')->willReturn($manager);
 
-        $action = new TrackAction($factory, $this->botDetector(false), $registry);
+        $action = new TrackAction($factory, $registry, $this->botDetector(false));
 
         $response = $action(new ClientInformation());
 
@@ -51,7 +51,32 @@ final class TrackActionTest extends TestCase
         $registry = $this->createMock(ManagerRegistry::class);
         $registry->expects(self::never())->method('getManagerForClass');
 
-        $action = new TrackAction($factory, $this->botDetector(true), $registry);
+        $action = new TrackAction($factory, $registry, $this->botDetector(true));
+
+        $response = $action(new ClientInformation());
+
+        self::assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     */
+    public function it_persists_without_a_bot_detector_for_backwards_compatibility(): void
+    {
+        $source = new Source();
+
+        $factory = $this->createMock(SourceFactoryInterface::class);
+        $factory->method('createFromClientInformation')->willReturn($source);
+
+        $manager = $this->createMock(EntityManagerInterface::class);
+        $manager->expects(self::once())->method('persist')->with($source);
+        $manager->expects(self::once())->method('flush');
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getManagerForClass')->willReturn($manager);
+
+        // Legacy two-argument construction (no bot detector) must still work
+        $action = new TrackAction($factory, $registry);
 
         $response = $action(new ClientInformation());
 

--- a/tests/Controller/Action/TrackActionTest.php
+++ b/tests/Controller/Action/TrackActionTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusConversionAttributionPlugin\Tests\Controller\Action;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\TestCase;
+use Setono\BotDetectionBundle\BotDetector\BotDetectorInterface;
+use Setono\SyliusConversionAttributionPlugin\ClientInformation\ClientInformation;
+use Setono\SyliusConversionAttributionPlugin\Controller\Action\TrackAction;
+use Setono\SyliusConversionAttributionPlugin\Factory\SourceFactoryInterface;
+use Setono\SyliusConversionAttributionPlugin\Model\Source;
+use Symfony\Component\HttpFoundation\Response;
+
+final class TrackActionTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_persists_a_source_for_a_regular_request(): void
+    {
+        $source = new Source();
+
+        $factory = $this->createMock(SourceFactoryInterface::class);
+        $factory->method('createFromClientInformation')->willReturn($source);
+
+        $manager = $this->createMock(EntityManagerInterface::class);
+        $manager->expects(self::once())->method('persist')->with($source);
+        $manager->expects(self::once())->method('flush');
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getManagerForClass')->willReturn($manager);
+
+        $action = new TrackAction($factory, $this->botDetector(false), $registry);
+
+        $response = $action(new ClientInformation());
+
+        self::assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     */
+    public function it_ignores_bot_requests_without_persisting(): void
+    {
+        $factory = $this->createMock(SourceFactoryInterface::class);
+        $factory->expects(self::never())->method('createFromClientInformation');
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->expects(self::never())->method('getManagerForClass');
+
+        $action = new TrackAction($factory, $this->botDetector(true), $registry);
+
+        $response = $action(new ClientInformation());
+
+        self::assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+    }
+
+    private function botDetector(bool $isBot): BotDetectorInterface
+    {
+        $botDetector = $this->createMock(BotDetectorInterface::class);
+        $botDetector->method('isBotRequest')->willReturn($isBot);
+
+        return $botDetector;
+    }
+}

--- a/tests/EventSubscriber/AddJavascriptSubscriberTest.php
+++ b/tests/EventSubscriber/AddJavascriptSubscriberTest.php
@@ -135,22 +135,52 @@ final class AddJavascriptSubscriberTest extends TestCase
 
     /**
      * @test
+     *
+     * @group legacy
      */
-    public function it_falls_back_to_the_session_window_when_no_source_matcher_is_injected(): void
+    public function it_triggers_a_deprecation_and_falls_back_when_no_source_matcher_is_injected(): void
     {
         $tagBag = $this->createMock(TagBagInterface::class);
         $tagBag->expects(self::never())->method('add');
 
-        // Legacy wiring: no source matcher. A recent cookie must still short-circuit tracking
-        // (and the missing matcher must not blow up).
-        $subscriber = $this->createSubscriber(
-            tagBag: $tagBag,
-            clientInformation: new ClientInformation(),
-            sourceMatcher: null,
-            cookie: new Cookie('client-id'),
-        );
+        // Legacy wiring: no source matcher. Construction must warn about the deprecation, and a
+        // recent cookie must still short-circuit tracking (the missing matcher must not blow up).
+        $deprecations = $this->captureDeprecations(function () use ($tagBag): void {
+            $subscriber = $this->createSubscriber(
+                tagBag: $tagBag,
+                clientInformation: new ClientInformation(),
+                sourceMatcher: null,
+                cookie: new Cookie('client-id'),
+            );
 
-        $subscriber->addJavascript($this->createRequestEvent());
+            $subscriber->addJavascript($this->createRequestEvent());
+        });
+
+        self::assertNotEmpty($deprecations);
+        self::assertStringContainsString('$sourceMatcher', $deprecations[0]);
+    }
+
+    /**
+     * Runs $callback with a temporary handler that records E_USER_DEPRECATED messages.
+     *
+     * @return list<string>
+     */
+    private function captureDeprecations(callable $callback): array
+    {
+        $deprecations = [];
+        set_error_handler(static function (int $errno, string $errstr) use (&$deprecations): bool {
+            $deprecations[] = $errstr;
+
+            return true;
+        }, \E_USER_DEPRECATED);
+
+        try {
+            $callback();
+        } finally {
+            restore_error_handler();
+        }
+
+        return $deprecations;
     }
 
     private function createSubscriber(

--- a/tests/EventSubscriber/AddJavascriptSubscriberTest.php
+++ b/tests/EventSubscriber/AddJavascriptSubscriberTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusConversionAttributionPlugin\Tests\EventSubscriber;
+
+use PHPUnit\Framework\TestCase;
+use Setono\BotDetectionBundle\BotDetector\BotDetectorInterface;
+use Setono\Client\Cookie;
+use Setono\ClientBundle\CookieProvider\CookieProviderInterface;
+use Setono\SyliusConversionAttributionPlugin\ClientInformation\ClientInformation;
+use Setono\SyliusConversionAttributionPlugin\EventSubscriber\AddJavascriptSubscriber;
+use Setono\SyliusConversionAttributionPlugin\Matcher\Source;
+use Setono\SyliusConversionAttributionPlugin\Matcher\SourceMatcherInterface;
+use Setono\SyliusConversionAttributionPlugin\Resolver\ClientInformationResolverInterface;
+use Setono\TagBag\Tag\InlineScriptTag;
+use Setono\TagBag\Tag\TagInterface;
+use Setono\TagBag\TagBagInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final class AddJavascriptSubscriberTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_escapes_client_information_so_it_cannot_break_out_of_the_inline_script(): void
+    {
+        // Values an attacker can influence via the URL / Referer / User-Agent headers
+        $clientInformation = new ClientInformation();
+        $clientInformation->source = "src'BREAK";
+        $clientInformation->medium = 'med<BREAK';
+        $clientInformation->campaign = 'camp&BREAK';
+        $clientInformation->page = 'page"BREAK';
+        $clientInformation->referrer = 'https://evil/</script>';
+
+        $capturedTag = null;
+        $tagBag = $this->createMock(TagBagInterface::class);
+        $tagBag->expects(self::once())->method('add')->with(self::callback(
+            static function (TagInterface $tag) use (&$capturedTag): bool {
+                $capturedTag = $tag;
+
+                return true;
+            },
+        ));
+
+        $subscriber = $this->createSubscriber(
+            tagBag: $tagBag,
+            clientInformation: $clientInformation,
+            sourceMatcher: $this->matcherReturning(null),
+            cookie: null,
+        );
+
+        $subscriber->addJavascript($this->createRequestEvent());
+
+        self::assertInstanceOf(InlineScriptTag::class, $capturedTag);
+        $content = $capturedTag->getContent();
+
+        // The payload must appear only in its fully hardened form, where ', ", <, > and & are
+        // rendered as \uXXXX escapes
+        $hardened = json_encode(
+            $clientInformation,
+            \JSON_THROW_ON_ERROR | \JSON_HEX_TAG | \JSON_HEX_APOS | \JSON_HEX_QUOT | \JSON_HEX_AMP,
+        );
+        self::assertStringContainsString($hardened, $content);
+
+        // None of the raw break-out sequences may survive into the <script> body
+        self::assertStringNotContainsString("src'BREAK", $content);
+        self::assertStringNotContainsString('med<BREAK', $content);
+        self::assertStringNotContainsString('camp&BREAK', $content);
+        self::assertStringNotContainsString('</script>', $content);
+    }
+
+    /**
+     * @test
+     */
+    public function it_tracks_a_campaign_click_even_within_the_session_window(): void
+    {
+        $tagBag = $this->createMock(TagBagInterface::class);
+        $tagBag->expects(self::once())->method('add');
+
+        $subscriber = $this->createSubscriber(
+            tagBag: $tagBag,
+            clientInformation: new ClientInformation(),
+            // A campaign marker was matched on this request ...
+            sourceMatcher: $this->matcherReturning(new Source('google', 'cpc')),
+            // ... even though the visitor was seen a moment ago
+            cookie: new Cookie('client-id'),
+        );
+
+        $subscriber->addJavascript($this->createRequestEvent());
+    }
+
+    /**
+     * @test
+     */
+    public function it_skips_a_non_campaign_request_within_the_session_window(): void
+    {
+        $tagBag = $this->createMock(TagBagInterface::class);
+        $tagBag->expects(self::never())->method('add');
+
+        $subscriber = $this->createSubscriber(
+            tagBag: $tagBag,
+            clientInformation: new ClientInformation(),
+            sourceMatcher: $this->matcherReturning(null),
+            cookie: new Cookie('client-id'),
+        );
+
+        $subscriber->addJavascript($this->createRequestEvent());
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_track_bot_requests(): void
+    {
+        $tagBag = $this->createMock(TagBagInterface::class);
+        $tagBag->expects(self::never())->method('add');
+
+        $sourceMatcher = $this->createMock(SourceMatcherInterface::class);
+        $sourceMatcher->expects(self::never())->method('match');
+
+        $subscriber = $this->createSubscriber(
+            tagBag: $tagBag,
+            clientInformation: new ClientInformation(),
+            sourceMatcher: $sourceMatcher,
+            cookie: null,
+            isBot: true,
+        );
+
+        $subscriber->addJavascript($this->createRequestEvent());
+    }
+
+    private function createSubscriber(
+        TagBagInterface $tagBag,
+        ClientInformation $clientInformation,
+        SourceMatcherInterface $sourceMatcher,
+        ?Cookie $cookie,
+        bool $isBot = false,
+    ): AddJavascriptSubscriber {
+        $resolver = $this->createMock(ClientInformationResolverInterface::class);
+        $resolver->method('resolve')->willReturn($clientInformation);
+
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $urlGenerator->method('generate')->willReturn('/track');
+
+        $botDetector = $this->createMock(BotDetectorInterface::class);
+        $botDetector->method('isBotRequest')->willReturn($isBot);
+
+        $cookieProvider = $this->createMock(CookieProviderInterface::class);
+        $cookieProvider->method('getCookie')->willReturn($cookie);
+
+        return new AddJavascriptSubscriber(
+            $tagBag,
+            $resolver,
+            $urlGenerator,
+            $botDetector,
+            $cookieProvider,
+            $sourceMatcher,
+            1800,
+        );
+    }
+
+    private function matcherReturning(?Source $source): SourceMatcherInterface
+    {
+        $matcher = $this->createMock(SourceMatcherInterface::class);
+        $matcher->method('match')->willReturn($source);
+
+        return $matcher;
+    }
+
+    private function createRequestEvent(): RequestEvent
+    {
+        return new RequestEvent(
+            $this->createMock(HttpKernelInterface::class),
+            Request::create('https://shop.example/'),
+            HttpKernelInterface::MAIN_REQUEST,
+        );
+    }
+}

--- a/tests/EventSubscriber/AddJavascriptSubscriberTest.php
+++ b/tests/EventSubscriber/AddJavascriptSubscriberTest.php
@@ -133,10 +133,30 @@ final class AddJavascriptSubscriberTest extends TestCase
         $subscriber->addJavascript($this->createRequestEvent());
     }
 
+    /**
+     * @test
+     */
+    public function it_falls_back_to_the_session_window_when_no_source_matcher_is_injected(): void
+    {
+        $tagBag = $this->createMock(TagBagInterface::class);
+        $tagBag->expects(self::never())->method('add');
+
+        // Legacy wiring: no source matcher. A recent cookie must still short-circuit tracking
+        // (and the missing matcher must not blow up).
+        $subscriber = $this->createSubscriber(
+            tagBag: $tagBag,
+            clientInformation: new ClientInformation(),
+            sourceMatcher: null,
+            cookie: new Cookie('client-id'),
+        );
+
+        $subscriber->addJavascript($this->createRequestEvent());
+    }
+
     private function createSubscriber(
         TagBagInterface $tagBag,
         ClientInformation $clientInformation,
-        SourceMatcherInterface $sourceMatcher,
+        ?SourceMatcherInterface $sourceMatcher,
         ?Cookie $cookie,
         bool $isBot = false,
     ): AddJavascriptSubscriber {
@@ -158,8 +178,8 @@ final class AddJavascriptSubscriberTest extends TestCase
             $urlGenerator,
             $botDetector,
             $cookieProvider,
-            $sourceMatcher,
             1800,
+            $sourceMatcher,
         );
     }
 

--- a/tests/Model/SourceTest.php
+++ b/tests/Model/SourceTest.php
@@ -21,4 +21,13 @@ final class SourceTest extends TestCase
         self::assertSame('google', $source->getSource());
         self::assertSame('organic', $source->getMedium());
     }
+
+    /**
+     * @test
+     */
+    public function it_has_no_id_before_it_is_persisted(): void
+    {
+        // The id is assigned by the database (integer auto-increment), not generated in the constructor
+        self::assertNull((new Source())->getId());
+    }
 }

--- a/tests/Parser/ReferrerParserFunctionalTest.php
+++ b/tests/Parser/ReferrerParserFunctionalTest.php
@@ -80,5 +80,11 @@ final class ReferrerParserFunctionalTest extends TestCase
     {
         yield ['https://example.com/foo/bar'];
         yield ['https://example.com'];
+
+        // Paths that produce a cache key containing PSR-6 reserved characters ((), :, @) must be
+        // treated as a cache miss instead of throwing (which would surface as an HTTP 500). A real
+        // world trigger is a Wikipedia article whose title contains parentheses.
+        yield ['https://unknown-referrer-example-xyz.test/wiki/Foo_(disambiguation)'];
+        yield ['https://unknown-referrer-example-xyz.test/a:b@c'];
     }
 }


### PR DESCRIPTION
## Summary

An audit of the plugin surfaced one security-critical defect and a set of correctness, robustness, and forward-compatibility issues. This PR fixes them, adds tests for each, and keeps the changes backwards compatible except for one intentional (accepted) break called out below.

## Fixes

### 🔴 Security — XSS in the injected tracking JS
`EventSubscriber\AddJavascriptSubscriber` interpolated `json_encode($clientInformation)` **raw** into an inline `<script>` (the tag-bag renderer does no escaping). `json_encode` does not escape `'`, and `page`/`referrer`/`userAgent` are attacker-influenced (URL, `Referer`, `User-Agent`), so a crafted link yielded reflected XSS. Now encoded with `JSON_HEX_TAG|JSON_HEX_APOS|JSON_HEX_QUOT|JSON_HEX_AMP`.

### 🟠 Availability — referrer with reserved characters → HTTP 500
`Parser\ReferrerParser` builds a PSR-6 cache key from the referrer host+path. A path containing reserved characters (`(){}@:` — e.g. a Wikipedia `..._(disambiguation)` URL) made the cache adapter throw `InvalidArgumentException` from inside a `kernel.request` listener, i.e. a **500 on an ordinary page**. Now caught and treated as a cache miss.

### 🟠 Attribution — mid-session campaign clicks were dropped
The session-timeout gate skipped tracking for any visitor seen within `session_timeout`, so a paid click (utm/click-id/cross-host referrer) arriving after an organic entry was never recorded and the order was misattributed to the organic touch. Campaign-carrying requests now bypass the gate.

### `/track` hardening
- Validation constraints on the `ClientInformation` payload, so an over-long value returns **422** at the `MapRequestPayload` boundary instead of a 500 on flush.
- Bot guard on the anonymous endpoint (matched on the real request User-Agent) so automated hits don't flood the source table.

### Robustness / forward-compat
- `CacheWarmer\ReferrersCacheWarmer`: explicit HTTP timeout (a hung host previously stalled `cache:warmup`/deploys) and a warning log instead of silently degrading attribution. Uses `LoggerAwareInterface` + a `NullLogger` default (non-nullable logger, unchanged constructor).
- `PruneCommand`: `getScalarResult()` returns rows (`['id' => x]`); switched to a flat `array_column(...)` id list plus a 1000-row batch. **Not a correctness bug** — the old form worked (Doctrine coerces the rows for `IN()`) but issued one DELETE per row; this is a clarity + efficiency change.
- `Resolver\ClientInformationResolver::resolve()` made explicitly nullable (PHP 8.4).
- `Model\Source` id: dropped the UUIDv7 that the constructor generated and Doctrine silently discarded; the model now uses `?int`, matching the integer auto-increment mapping (see the accepted break below).

### Docs
README notes on the prune cron, GDPR (IP/user-agent retention), the **full-page-cache shared-client-id caveat**, and optional runtime dependencies.

## Backwards compatibility

New service dependencies are added the Symfony way — appended **last, nullable, defaulting to `null`**, with a `trigger_deprecation()` when omitted so integrators know to start passing them and maintainers can grep `trigger_deprecation` to remove the shims in the next major:
- `AddJavascriptSubscriber` — `$sourceMatcher`
- `TrackAction` — `$botDetector`

(`ReferrersCacheWarmer` keeps its original single-argument constructor by using `LoggerAwareInterface` setter injection, so it needs no shim.) The pattern is documented in `CLAUDE.md`.

**One intentional break (accepted):** `Model\Source::getId()` return type changes from `string` to `?int`. The `Backwards Compatibility Check` job flags this; it is deliberate (the id was always the integer PK; the old `string` came from the now-removed UUID) and the `SourceInterface`/Sylius `ResourceInterface::getId(): mixed` contract is unchanged.

## Dependencies
- `require`: `+symfony/validator` (constraints), `+psr/log` (logger), `+symfony/deprecation-contracts` (`trigger_deprecation`); `-symfony/uid` (last use removed, still present transitively).
- `composer-dependency-analyser.php`: ignore the `unused-dependency` false positive for `symfony/deprecation-contracts` (its only symbol is the `files`-autoloaded `trigger_deprecation()`, which the CI job — run after `require-dev` is uninstalled — cannot attribute to the package).

## Testing
- `composer phpunit` — 33 tests, covering every change (XSS escaping, referrer crash, prune, source id, mid-session tracking, `/track` validation + bot guard, and the `@group legacy` deprecation paths).
- Psalm (level 1), ECS, `composer normalize`, `lint:container` — clean.
- Infection: **MSI 66%, Covered MSI 100%**, 0 escaped. `minMsi` raised 42.54 → 60.

## Follow-up
- #7 — rework the tracking snippet to read the client id from the cookie client-side, making it safe under full-page caching (the caveat documented here).